### PR TITLE
sys-power/nut: Upgrade to 2.7.2.

### DIFF
--- a/packages/sys-power/nut/files/nut-2.7.2-systemd-unit-dir-braindamage.patch
+++ b/packages/sys-power/nut/files/nut-2.7.2-systemd-unit-dir-braindamage.patch
@@ -1,0 +1,15 @@
+Source: written by Calvin Walton <calvin.walton@kepstin.ca>
+Upstream: https://github.com/networkupstools/nut/pull/179
+Reason: Fix installation path for systemd unit files
+diff --git a/configure.ac b/configure.ac
+index c746db4..0045c23 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1063,7 +1063,6 @@ dnl files will try to get intalled to the actual system directories
+ if test -n "${systemdsystemunitdir}"; then
+ 	systemdsystemshutdowndir="${libdir}/systemd/system-shutdown"
+ 	AC_MSG_RESULT(using ${systemdsystemunitdir})
+-	systemdsystemunitdir="`echo ${systemdsystemunitdir} | sed 's/\/lib/\${libdir}/'`"
+ else
+ 	AC_MSG_RESULT(no)
+ fi

--- a/packages/sys-power/nut/nut-2.7.2.exheres-0
+++ b/packages/sys-power/nut/nut-2.7.2.exheres-0
@@ -1,0 +1,121 @@
+# Copyright 2012 Calvin Walton <calvin.walton@kepstin.ca>
+# Distributed under the terms of the GNU General Public License v2
+
+require systemd-service udev-rules
+
+SUMMARY="Network UPS Tools"
+DESCRIPTION="
+Network UPS Tools (NUT) is a client/server monitoring system that allows
+computers to share uninterruptible power supply (UPS) and power distribution
+unit (PDU) hardware. Clients access the hardware through the server, and are
+notified whenever the power status changes.
+"
+HOMEPAGE="http://www.networkupstools.org/"
+DOWNLOADS="http://www.networkupstools.org/source/$(ever range 1-2)/${PNV}.tar.gz"
+
+LICENCES="GPL-2"
+# Note: The Python library is GPL-3, and the Perl module is GPL-1+/Artistic
+# Neither is currently installed.
+
+require autotools [ supported_autoconf=[ 2.5 ] supported_automake=[ 1.11 ] ]
+
+SLOT="0"
+PLATFORMS="~amd64"
+MYOPTIONS="
+    avahi
+    ssl
+    systemd
+    tcpd
+    nut_drivers:
+        powerman [[ description = [ Powerman PDU ] ]]
+        serial [[ description = [ serial (RS-232) UPS devices ] ]]
+        snmp [[ description = [ UPS devices with SNMP interface ] ]]
+        usb [[ description = [ USB-connected UPS devices ] ]]
+        xml [[ description = [ UPS devices with XML/HTTP interface ] ]]
+"
+# Currently, the following features aren't enabled:
+# ipmi driver - needs FreeIPMI (and not OpenIPMI...)
+# cgi - web interface to NUT. Needs external web server and gd.
+# Python and Perl libraries
+# Compile html/pdf documentation
+
+DEPENDENCIES="
+    build:
+        dev-util/pkg-config
+    build+run:
+        user/nut
+        avahi? ( net-dns/avahi[>=0.6.30] )
+        ssl? ( dev-libs/openssl )
+        tcpd? ( sys-apps/tcp-wrappers )
+
+        nut_drivers:powerman? ( sys-power/powerman )
+        nut_drivers:snmp? ( net/net-snmp )
+        nut_drivers:usb? ( dev-libs/libusb:0.1 )
+        nut_drivers:xml? ( net-misc/neon[>=0.25.0] )
+"
+
+DEFAULT_SRC_CONFIGURE_PARAMS=(
+    --sysconfdir=/etc/nut
+    --datarootdir=/usr/share/nut
+    --datadir=/usr/share/nut
+    --htmldir=/usr/share/doc/${PNVR}/html
+
+    --with-drvpath=/usr/sbin
+    --with-statepath=/run/nut
+    --with-pidpath=/run/nut
+    --with-altpidpath=/run/nut
+    --without-hotplug-dir
+
+    --with-user=nut
+    --with-group=nut
+
+    --disable-static
+
+    --with-dev
+    --without-ipmi
+    --with-libltdl
+    --without-doc
+)
+DEFAULT_SRC_CONFIGURE_OPTION_WITHS=(
+    avahi
+    ssl
+    "ssl openssl"
+    "systemd systemdsystemunitdir ${SYSTEMDSYSTEMUNITDIR}"
+    "tcpd wrap"
+    nut_drivers:powerman
+    nut_drivers:serial
+    nut_drivers:snmp
+    nut_drivers:usb
+    "nut_drivers:xml neon"
+    "nut_drivers:usb udev-dir ${UDEVRULESDIR%/rules.d}"
+)
+
+src_prepare() {
+    expatch "${FILES}"/nut-2.7.2-systemd-unit-dir-braindamage.patch
+
+    AT_M4DIR=m4 eautoreconf
+}
+
+src_install() {
+    default
+
+    # Set permissions on config files that shouldn't be world-readable.
+    edo chmod 0640 "${IMAGE}"/etc/nut/upsd.conf.sample \
+                   "${IMAGE}"/etc/nut/upsd.users.sample
+    edo chgrp nut "${IMAGE}"/etc/nut/upsd.conf.sample \
+                  "${IMAGE}"/etc/nut/upsd.users.sample
+
+    if option systemd; then
+        # Automatically create the /run/nut directory
+        insinto /usr/${LIBDIR}/tmpfiles.d
+        doins "${FILES}"/tmpfiles.d/nut.conf
+    fi
+}
+
+pkg_postinst() {
+    if [[ "${ROOT}" == / ]] && option systemd; then
+        # Create the /run/nut directory right away so people can start the
+        # services without rebooting or a manual step.
+        edo systemd-tmpfiles --create /usr/${LIBDIR}/tmpfiles.d/nut.conf
+    fi
+}


### PR DESCRIPTION
Fix the issue of unstalling empty udev rules dirs when
compiling without USB support.
